### PR TITLE
add wsl2 nightly stage

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -82,6 +82,21 @@ pipeline {
         }
       }
     }
+    stage("WSL2 Nightly Test Stage") {
+      agent {label 'wsl2'}
+      when { environment name: 'BUILD_TYPE', value: 'nightly' }
+      options {
+        timeout(time: 10, unit: 'MINUTES', activity: true)
+      }
+      environment { UPLOAD_PKGS = "false" }
+      steps {
+        script {
+          parallel generateStage("nightly_test",{
+            sh "./ci/gpu_test.sh"
+          })
+        }
+      }
+    }
     stage("Upload Anaconda Packages") {
       environment {
         STABLE_CONDA_TOKEN = credentials('rapidsai-conda-upload-api')


### PR DESCRIPTION
Added changes to Jenkinsfile to include a parallel nightly test running on a Jenkins WSL2 agent. WSL2 agent is needed to verify the rmm builds will work properly when run on user systems that are running Ubuntu in a windows environment.